### PR TITLE
Fix to return specific rate from response

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -78,7 +78,7 @@ class Response
         
         if( $this->body->rates->{$code} )
         {
-            return $this->body->rates[$code];
+            return $this->body->rates->{$code};
         }
         
         return null;


### PR DESCRIPTION
This is a little fix to a bug I found. The following would error as it was trying to access an object as an array. 

```
$lookup = new \BenMajor\ExchangeRatesAPI\ExchangeRatesAPI();
$rates  = $lookup->setBaseCurrency('GBP')->fetch();

echo $rates->getRate('EUR');
```