### PR TITLE
Add/Remove multiple currencies at once. Fix removeRate

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,18 @@ Set the base currency to be used for exchange rates. `$code` should be passed an
 `getBaseCurrency()`:<br />
 Returns the currently specified base currency. If `setBaseCurrency()` hasn't been called, this will return the default base currency `EUR`.
 
+`addRates( array $codes )`:<br />
+Adds multiple currencies to be retrieved. `$codes` should be an array of ISO 4217 codes (e.g. `["EUR", "GBP", "BGN"]`).<br />
+Each code in the array must be of the [supported currency codes](#5-supported-currencies).<br />
+ 
 `addRate( string $code )`:<br />
 Adds a new currency to be retrieved. `$code` should be passed an ISO 4217 code (e.g. `EUR`).<br />
 `$code` must be one of the [supported currency codes](#5-supported-currencies).<br />
 If no rates are added, **all** rates will be returned.
+
+`removeRates( array $codes )`:<br />
+Removes multiple currencies that has already been added to the retrieval list.  `$codes` should be an array of ISO 4217 codes (e.g. `["EUR", "GBP", "BGN"]`).<br />
+`$code` must be one of the [supported currency codes](#5-supported-currencies).
 
 `removeRate( string $code )`:<br />
 Removes a currency that has already been added to the retrieval list.  `$code` should be passed an ISO 4217 code (e.g. `EUR`).<br />

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -139,7 +139,7 @@ class ExchangeRatesAPI
         throw new Exception( $this->_errors['format.invalid_date'] );
     }
     
-    #�Remove the date-to:
+    # Remove the date-to:
     public function removeDateTo()
     {
         $this->dateTo = null;
@@ -303,7 +303,7 @@ class ExchangeRatesAPI
             $params['symbols'] = $this->getRates(',');
         }
         
-        #�Begin the sending:
+        # Begin the sending:
         try
         {
             $guzzleResponse = $this->client->request('GET', $endpoint, [ 'query' => $params ]);

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -139,7 +139,7 @@ class ExchangeRatesAPI
         throw new Exception( $this->_errors['format.invalid_date'] );
     }
     
-    #ÊRemove the date-to:
+    #ï¿½Remove the date-to:
     public function removeDateTo()
     {
         $this->dateTo = null;
@@ -175,7 +175,17 @@ class ExchangeRatesAPI
         # Return object to preserve method-chaining:
         return $this;
     }
-    
+
+    # Add multiple currencies at once
+    public function addRates( array $currencies )
+    {
+        foreach ($currencies as $currency)
+        {
+            $this->addRate($currency);
+        }
+        return $this;
+    }
+
     # Add a currency to the returned rates:
     public function addRate( string $currency )
     {
@@ -189,7 +199,17 @@ class ExchangeRatesAPI
         # Return object to preserve method-chaining:
         return $this;
     }
-    
+
+    # Remove multiple currencies at once
+    public function removeRates( array $currencies )
+    {
+        foreach ($currencies as $currency)
+        {
+            $this->removeRate($currency);
+        }
+        return $this;
+    }
+
     # Remove a currency from the returned rates:
     public function removeRate( string $currency )
     {
@@ -197,7 +217,7 @@ class ExchangeRatesAPI
         $currencyCode = $this->sanitizeCurrencyCode($currency);
         
         # Verify it's valid:
-        $this->verifyCurrencyCode();
+        $this->verifyCurrencyCode($currencyCode);
         
         $newRates = [ ];
         
@@ -283,7 +303,7 @@ class ExchangeRatesAPI
             $params['symbols'] = $this->getRates(',');
         }
         
-        #ÊBegin the sending:
+        #ï¿½Begin the sending:
         try
         {
             $guzzleResponse = $this->client->request('GET', $endpoint, [ 'query' => $params ]);


### PR DESCRIPTION
First thanks for the nice wrapper. 

I found it useful if multiple currencies can be added/removed from the request/response at once.
Also spotted a small issue in the removeRate method where it calls the internal verifyCurrencyCode without passing the actual currency code.
