### PR TITLE
Library update to facilitate the new exchangeratesapi.io requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ use \BenMajor\ExchangeRatesAPI\Response;
 use \BenMajor\ExchangeRatesAPI\Exception;
 
 $access_key = '<YOUR ACCESS KEY>';
+$use_ssl = false; # Free plans are restricted to non-SSL only.
 
-$lookup = new ExchangeRatesAPI($access_key, false);
+$lookup = new ExchangeRatesAPI($access_key, $use_ssl);
 $rates  = $lookup->fetch();
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ use \BenMajor\ExchangeRatesAPI\ExchangeRatesAPI;
 use \BenMajor\ExchangeRatesAPI\Response;
 use \BenMajor\ExchangeRatesAPI\Exception;
 
-$lookup = new ExchangeRatesAPI();
+$access_key = '<YOUR ACCESS KEY>';
+
+$lookup = new ExchangeRatesAPI($access_key, false);
 $rates  = $lookup->fetch();
 ```
 
@@ -56,14 +58,18 @@ $rates  = $lookup->fetch();
 Get historical rates for any day since 1999:
 
 ```
-$lookup = new ExchangeRatesAPI();
+$access_key = '<YOUR ACCESS KEY>';
+
+$lookup = new ExchangeRatesAPI($access_key);
 $rates  = $lookup->setFetchDate('2015-01-20')->fetch();
 ```
 
 Get historical rates for a time period:
 
 ```
-$lookup = new ExchangeRatesAPI();
+$access_key = '<YOUR ACCESS KEY>';
+
+$lookup = new ExchangeRatesAPI($access_key);
 $rates  = $lookup->addDateFrom('2015-01-20')->addDateTo('2015-01-21')->fetch();
 ```
 
@@ -71,7 +77,9 @@ $rates  = $lookup->addDateFrom('2015-01-20')->addDateTo('2015-01-21')->fetch();
 By default, the base currency is set to Euro (EUR), but it can be changed: 
 
 ```
-$lookup = new ExchangeRatesAPI();
+$access_key = '<YOUR ACCESS KEY>';
+
+$lookup = new ExchangeRatesAPI($access_key);
 $rates  = $lookup->setBaseCurrency('GBP')->fetch();
 ```
 
@@ -79,7 +87,9 @@ $rates  = $lookup->setBaseCurrency('GBP')->fetch();
 If you do not want all current rates, it's possible to specify only the currencies you want using `addRate()`. The following code fetches only the exchange rate between GBP and EUR:
 
 ```
-$lookup = new ExchangeRatesAPI();
+$access_key = '<YOUR ACCESS KEY>';
+
+$lookup = new ExchangeRatesAPI($access_key);
 $rates  = $lookup->addRate('EUR')->setBaseCurrency('GBP')->fetch();
 ```
 
@@ -107,6 +117,12 @@ Set the end date for the retrieval of historic rates. `$to` should be a string c
 
 `getDateTo()`:<br />
 Returns the specified end date for the retrieval of historic rates. Returns `null` if none is specified.
+
+`getAccessKey()`:<br />
+Returns the `access_key` that is currently in use.
+
+`getUseSSL()`:<br />
+Returns a boolean flag that determines which API URL will be used to perform requests. Free plans are restricted to non-SSL usage.
 
 `removeDateTo()`:<br />
 Removes the specified end date for the retrieval of historic rates.
@@ -138,6 +154,12 @@ Removes multiple currencies that has already been added to the retrieval list.  
 `removeRate( string $code )`:<br />
 Removes a currency that has already been added to the retrieval list.  `$code` should be passed an ISO 4217 code (e.g. `EUR`).<br />
 `$code` must be one of the [supported currency codes](#5-supported-currencies).
+
+`setAccessKey( string $access_key )`:<br />
+Sets `access_key` to be used in all requests.
+
+`setUseSSL( bool $use_ssl )`:<br />
+Sets the API URL according to the selected mode (SSL or non-SSL). Free plans are restricted to non-SSL usage.
 
 `fetch( bool $returnJSON = false, bool $parseJSON = true )`:<br />
 Send off the request to the API and return either a `Response` object, or the raw JSON response. If `$returnJSON` is set to `true`, a standard PHP object will be returned, rather than the `ExchangeRatesAPI\Response` object. 

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -13,6 +13,12 @@ namespace BenMajor\ExchangeRatesAPI;
 
 class ExchangeRatesAPI
 {
+    # Default API URL:
+    const API_URL_SSL = 'https://api.exchangeratesapi.io/';
+    
+    # Free plan API URL:
+    const API_URL_NON_SSL = 'http://api.exchangeratesapi.io/';
+    
     # Fetch date
     private $fetchDate;
 
@@ -32,7 +38,7 @@ class ExchangeRatesAPI
     private $client;
     
     # The URL of the API:
-    private $apiURL = 'https://api.exchangeratesapi.io/';
+    private $apiURL = self::API_URL_SSL;
     
     # Regular Expression for the date:
     private $dateRegExp = '/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/';
@@ -57,8 +63,14 @@ class ExchangeRatesAPI
         'format.invalid_rounding'      => 'Rounding precision must be specified as a numeric value.'
     ];
     
-    function __construct(  )
+    # ExchangeRatesAPI Access Key:
+    private $access_key;
+    
+    function __construct( string $access_key = null, bool $use_ssl = true )
     {
+        $this->setAccessKey($access_key);
+        $this->setUseSSL($use_ssl);
+        
         $this->client = new \GuzzleHttp\Client([ 'base_uri' => $this->apiURL ]);
     }
     
@@ -102,6 +114,18 @@ class ExchangeRatesAPI
     public function getRates( string $concat = null )
     {
         return (! is_null($concat) ) ? implode($concat, $this->rates) : $this->rates;
+    }
+    
+    # Get access key:
+    public function getAccessKey()
+    {
+        return $this->access_key;
+    }
+    
+    # Get boolean flag for SSL usage:
+    public function getUseSSL()
+    {
+        return ($this->apiURL == self::API_URL_SSL);
     }
     
     /****************************/
@@ -259,6 +283,30 @@ class ExchangeRatesAPI
         return $this;
     }
     
+    # Set access key:
+    public function setAccessKey( string $access_key = null )
+    {
+        $this->access_key = $access_key;
+        
+        # Return object to preseve method chaining:
+        return $this;
+    }
+
+    # Set SSL flag and API URL:
+    public function setUseSSL( bool $use_ssl = true )
+    {
+        if ( $use_ssl )
+        {
+            $this->apiURL = self::API_URL_SSL;
+        }
+        else
+        {
+            $this->apiURL = self::API_URL_NON_SSL;
+        }
+        
+        return $this;
+    }
+
     /****************************/
     /*                          */
     /*   API FUNCTION CALLS     */
@@ -297,6 +345,12 @@ class ExchangeRatesAPI
     {
         # Build the URL:
         $params = [ ];
+        
+        # Set access key if available:
+        if ( !is_null($this->getAccessKey()) )
+        {
+            $params['access_key'] = $this->getAccessKey();
+        }
 
         # Set the relevant endpoint:
         if( is_null($this->dateFrom) )


### PR DESCRIPTION
Added access_key and SSL/non-SSL to the library. I tried to maintain roughly the same coding standards, to avoid unnecessary back and forth tweaks and changes and to keep the overall readability consistent.