### PR TITLE
Support for `source` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Sets `access_key` to be used in all requests.
 `setUseSSL( bool $use_ssl )`:<br />
 Sets the API URL according to the selected mode (SSL or non-SSL). Free plans are restricted to non-SSL usage.
 
-`setSource( string $source )`:<br />
-Sets the specified data source (other than the API default) from which to retrieve rates.
+`setSource( string $source = null )`:<br />
+Sets the specified data source (other than the API default) from which to retrieve rates. Calling with no arguments resets the source to the API default.
 
 `fetch( bool $returnJSON = false, bool $parseJSON = true )`:<br />
 Send off the request to the API and return either a `Response` object, or the raw JSON response. If `$returnJSON` is set to `true`, a standard PHP object will be returned, rather than the `ExchangeRatesAPI\Response` object. 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ Following pricing changes for [ExchangeRatesAPI](https://exchangerate.host/), th
 
 ## Table of Contents:
 
-1. [Installation](#2-installation)
-2. [Getting Started](#3-getting-started)
-3. [API Reference](#4-api-reference)
-4. [Supported Currencies](#5-supported-currencies)
-5. [Requirements](#6-requirements)
-6. [Bugs & Features](#7-bugs-features)
-7. [License](#8-license)
+1. [Installation](#1-installation)
+2. [Getting Started](#2-getting-started)
+3. [API Reference](#3-api-reference)
+4. [Supported Currencies](#4-supported-currencies)
+5. [Supported data sources](#5-supported-data-sources)
+6. [Requirements](#6-requirements)
+7. [Bugs & Features](#7-bugs-features)
+8. [License](#8-license)
 
 ---
 
@@ -132,29 +133,33 @@ Removes the specified end date for the retrieval of historic rates.
 Checks if a specific currency code is supported. `$code` should be passed as an ISO 4217 code (e.g. `EUR`).<br />
 Returns `true` if supported, or `false` if not.
 
+`sourceIsSupported( string $source )`:<br />
+Checks if a specific data source is supported.<br />
+Returns `true` if supported, or `false` if not.
+
 `setBaseCurrency( string $code )`:<br />
 Set the base currency to be used for exchange rates. `$code` should be passed an ISO 4217 code (e.g. `EUR`).<br />
-`$code` must be one of the [supported currency codes](#5-supported-currencies).
+`$code` must be one of the [supported currency codes](#4-supported-currencies).
 
 `getBaseCurrency()`:<br />
 Returns the currently specified base currency. If `setBaseCurrency()` hasn't been called, this will return the default base currency `EUR`.
 
 `addRates( array $codes )`:<br />
 Adds multiple currencies to be retrieved. `$codes` should be an array of ISO 4217 codes (e.g. `["EUR", "GBP", "BGN"]`).<br />
-Each code in the array must be of the [supported currency codes](#5-supported-currencies).<br />
+Each code in the array must be of the [supported currency codes](#4-supported-currencies).<br />
  
 `addRate( string $code )`:<br />
 Adds a new currency to be retrieved. `$code` should be passed an ISO 4217 code (e.g. `EUR`).<br />
-`$code` must be one of the [supported currency codes](#5-supported-currencies).<br />
+`$code` must be one of the [supported currency codes](#4-supported-currencies).<br />
 If no rates are added, **all** rates will be returned.
 
 `removeRates( array $codes )`:<br />
 Removes multiple currencies that has already been added to the retrieval list.  `$codes` should be an array of ISO 4217 codes (e.g. `["EUR", "GBP", "BGN"]`).<br />
-`$code` must be one of the [supported currency codes](#5-supported-currencies).
+`$code` must be one of the [supported currency codes](#4-supported-currencies).
 
 `removeRate( string $code )`:<br />
 Removes a currency that has already been added to the retrieval list.  `$code` should be passed an ISO 4217 code (e.g. `EUR`).<br />
-`$code` must be one of the [supported currency codes](#5-supported-currencies).
+`$code` must be one of the [supported currency codes](#4-supported-currencies).
 
 `setAccessKey( string $access_key )`:<br />
 Sets `access_key` to be used in all requests.
@@ -163,7 +168,8 @@ Sets `access_key` to be used in all requests.
 Sets the API URL according to the selected mode (SSL or non-SSL). Free plans are restricted to non-SSL usage.
 
 `setSource( string $source = null )`:<br />
-Sets the specified data source (other than the API default) from which to retrieve rates. Calling with no arguments resets the source to the API default.
+Sets the specified data source (other than the API default) from which to retrieve rates. Calling with no arguments resets the source to the API default.<br />
+If provided as a string, `$source` must be one of the [supported data sources](#5-supported-data-sources).
 
 `fetch( bool $returnJSON = false, bool $parseJSON = true )`:<br />
 Send off the request to the API and return either a `Response` object, or the raw JSON response. If `$returnJSON` is set to `true`, a standard PHP object will be returned, rather than the `ExchangeRatesAPI\Response` object. 
@@ -210,16 +216,19 @@ Retrieves the exchange rate for a specific currency, or returns the exchange rat
 
 The library supports any currency currently available on the European Central Bank's web service, which can be found [here](https://exchangeratesapi.io/currencies/).
 
-### 5. Requirements:
+### 5. Supported data sources:
+The library supports the following [data sources](https://api.exchangerate.host/sources) other than the API default.
+
+### 6. Requirements:
 
 This library requires PHP >= 7.0. No other platform requirements exist, but the library is dependent on [Guzzle](https://github.com/guzzle/guzzle).
 
 
-### 6. Bugs & Features:
+### 7. Bugs & Features:
 
 If you have spotted any bugs, or would like to request additional features from the library, please file an issue via the Issue Tracker on the project's Github page: [https://github.com/benmajor/ExchangeRatesAPI/issues](https://github.com/benmajor/ExchangeRatesAPI/issues).
 
-### 7. License:
+### 8. License:
 
 Licensed under the **MIT License**:
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Returns the `access_key` that is currently in use.
 `getUseSSL()`:<br />
 Returns a boolean flag that determines which API URL will be used to perform requests. Free plans are restricted to non-SSL usage.
 
+`getSource()`:<br />
+Returns the specified data source (other than the API default) from which to retrieve rates. Returns `null` if none is specified.
+
 `removeDateTo()`:<br />
 Removes the specified end date for the retrieval of historic rates.
 
@@ -158,6 +161,9 @@ Sets `access_key` to be used in all requests.
 
 `setUseSSL( bool $use_ssl )`:<br />
 Sets the API URL according to the selected mode (SSL or non-SSL). Free plans are restricted to non-SSL usage.
+
+`setSource( string $source )`:<br />
+Sets the specified data source (other than the API default) from which to retrieve rates.
 
 `fetch( bool $returnJSON = false, bool $parseJSON = true )`:<br />
 Send off the request to the API and return either a `Response` object, or the raw JSON response. If `$returnJSON` is set to `true`, a standard PHP object will be returned, rather than the `ExchangeRatesAPI\Response` object. 

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -334,8 +334,12 @@ class ExchangeRatesAPI
     }
 
     # Set data source
-    public function setSource(string $source)
+    public function setSource(string $source = null)
     {
+        if ($source !== null) {
+            $source = $this->sanitizeSource($source);
+        }
+
         $this->source = $source;
 
         return $this;
@@ -516,6 +520,14 @@ class ExchangeRatesAPI
     {
         return trim(
             strtoupper( $code )
+        );
+    }
+
+    # Sanitize a data source:
+    private function sanitizeSource( string $source )
+    {
+        return trim(
+            strtolower( $source )
         );
     }
 }

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -70,6 +70,9 @@ class ExchangeRatesAPI
         'VND', 'VUV', 'WST', 'XAF', 'XAG', 'XAU', 'XCD', 'XDR',
         'XOF', 'XPF', 'YER', 'ZAR', 'ZMK', 'ZMW', 'ZWL',
         ];
+
+    # Data source (default is forex):
+    private $source;
     
     # Error messages:
     private $_errors = [
@@ -143,6 +146,12 @@ class ExchangeRatesAPI
     public function getUseSSL()
     {
         return ($this->apiURL == self::API_URL_SSL);
+    }
+
+    # Get data source
+    public function getSource()
+    {
+        return $this->source;
     }
     
     /****************************/
@@ -324,6 +333,14 @@ class ExchangeRatesAPI
         return $this;
     }
 
+    # Set data source
+    public function setSource(string $source)
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
     /****************************/
     /*                          */
     /*   API FUNCTION CALLS     */
@@ -401,6 +418,12 @@ class ExchangeRatesAPI
         if( count($this->rates) > 0 )
         {
             $params['symbols'] = $this->getRates(',');
+        }
+
+        # Set the data source:
+        if( ! is_null($this->getSource()) )
+        {
+            $params['source'] = $this->getSource();
         }
         
         # Begin the sending:

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -71,14 +71,18 @@ class ExchangeRatesAPI
         'XOF', 'XPF', 'YER', 'ZAR', 'ZMK', 'ZMW', 'ZWL',
         ];
 
-    # Data source (default is forex):
+    # Data source (default is forex which cannot be set explicitly):
     private $source;
-    
+
+    # Supported data sources:
+    private $_sources = ['imf', 'rba', 'boc', 'snb', 'cbr', 'nbu', 'bnro', 'boi', 'nob', 'cbn', 'ecb'];
+
     # Error messages:
     private $_errors = [
         'format.invalid_date'          => 'The specified date is invalid. Please use ISO 8601 notation (e.g. YYYY-MM-DD).',
         'format.invalid_currency_code' => 'The specified currency code is invalid. Please use ISO 4217 notation (e.g. EUR).',
         'format.unsupported_currency'  => 'The specified currency code is not currently supported.',
+        'format.unsupported_source'    => 'The specified data source is not currently supported.',
         'format.invalid_amount'        => 'Conversion amount must be specified as a numeric value.',
         'format.invalid_rounding'      => 'Rounding precision must be specified as a numeric value.'
     ];
@@ -229,8 +233,14 @@ class ExchangeRatesAPI
         {
             throw new Exception( $this->_errors['format.invalid_currency_code'] );
         }
-        
+
         return in_array( $currencyCode, $this->_currencies );
+    }
+
+    # Check if a data source is in the supported range:
+    public function sourceIsSupported( string $source )
+    {
+        return in_array( $this->sanitizeSource($source), $this->_sources );
     }
     
     # Set the base currency:
@@ -338,6 +348,7 @@ class ExchangeRatesAPI
     {
         if ($source !== null) {
             $source = $this->sanitizeSource($source);
+            $this->verifySource($source);
         }
 
         $this->source = $source;
@@ -512,6 +523,18 @@ class ExchangeRatesAPI
         if( ! $this->currencyIsSupported($currencyCode) )
         {
             throw new Exception( $this->_errors['format.unsupported_currency'] );
+        }
+    }
+
+    # Runs tests to verify a source:
+    private function verifySource( string $source )
+    {
+        $source = $this->sanitizeSource($source);
+
+        # Is it a supported source?
+        if( ! $this->sourceIsSupported($source) )
+        {
+            throw new Exception( $this->_errors['format.unsupported_source'] );
         }
     }
     


### PR DESCRIPTION
After switching to the https://exchangerate.host/ in #8 we have various data sources available at the API (see `source` parameter in https://exchangerate.host/#/docs). 

This PR supports:
- setting `source` to one of the bank sources linked in the documentation (the not included `crypto` is, strictly speaking, a valid option too, but in case of regular currencies it returns the same result as the default, so I would consider it out of scope, see if you agree)
- resetting `source` back to the API default (according to the docs, it's 'forex' which is not a valid option to be set explicitly as it returns `false` as a result)
- verifying the provided string against the internal hardcoded list of supported sources (similar as it's done with currency codes)

I'm slightly doubting about this last one, as in the current implementation the list has to be manually updated once a new source is introduced (not sure how often that can happen, but seems at least more likely than with the currencies). Possible alternatives I can think of:
- keep verifying the sources, but instead of a hardcoded list make an API call to the `sources` endpoint (and probably cache the results? or maybe allow users to verify a source once and then skip the verification on `set`)
- (probably the easiest) don't verify the source, leave it as user's responsibility to provide something that makes sense
If the preferred solution is the first one, can it be postponed for another future PR? 

Please let me know what you think.

P.S. I skipped the part of making an issue first, but so my justification for making a PR is that I would like to use your library with a custom source and currently I can't.
