### PR TITLE
Support access to the date property of the API response

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ Returns a key/value pair array of the exchange rates that match against the requ
 `getRate( string $code )`:<br />
 Retrieves the exchange rate for a specific currency, or returns the exchange rate if only one rate is present in the response. 
 
+`getDate()`:<br />
+Retrieves the date returned as part of the response (formatted as Y-m-d).
+
 ### 4. Supported Currencies:
 
 The library supports any currency currently available on the European Central Bank's web service, which can be found [here](https://exchangeratesapi.io/currencies/).

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Returns a key/value pair array of the exchange rates that match against the requ
 Retrieves the exchange rate for a specific currency, or returns the exchange rate if only one rate is present in the response. 
 
 `getDate()`:<br />
-Retrieves the date returned as part of the response (formatted as Y-m-d).
+Retrieves the date returned as part of the response (formatted as Y-m-d). If response has no `date` property, returns null.
 
 ### 4. Supported Currencies:
 

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -408,19 +408,19 @@ class ExchangeRatesAPI
         }
         else
         {
-            $endpoint = 'history';
+            $endpoint = 'timeseries';
         }
         
         # Add dateFrom if specified:
         if( ! is_null($this->getDateFrom()) )
         {
-            $params['start_at'] = $this->getDateFrom();
+            $params['start_date'] = $this->getDateFrom();
         }
         
         # Add a dateTo:
         if( ! is_null($this->getDateTo()) )
         {
-            $params['end_at'] = $this->getDateTo();
+            $params['end_date'] = $this->getDateTo();
         }
         
         # Set the base currency:

--- a/src/Response.php
+++ b/src/Response.php
@@ -16,6 +16,7 @@ class Response
     private $statusCode;
     private $timestamp;
     private $baseCurrency;
+    private $date;
     
     private $rates = [ ];
     
@@ -32,6 +33,7 @@ class Response
         $this->timestamp    = date('c');
         $this->baseCurrency = $this->body->base;
         $this->rates        = $this->body->rates;
+        $this->date         = date('Y-m-d', strtotime($this->body->date));
     }
     
     /****************************/
@@ -46,7 +48,7 @@ class Response
         return (int) $this->statusCode;
     }
     
-    #ÊGet the timestamp of the request:
+    # Get the timestamp of the request:
     public function getTimestamp()
     {
         return $this->timestamp;
@@ -56,6 +58,12 @@ class Response
     public function getBaseCurrency()
     {
         return $this->baseCurrency;
+    }
+
+    # Get the date specified in the response:
+    public function getDate()
+    {
+        return $this->date;
     }
     
     # Get the exchange rates:
@@ -84,12 +92,13 @@ class Response
         return null;
     }
     
-    #ÊConvert the response to JSON:
+    # Convert the response to JSON:
     public function toJSON()
     {
         return json_encode([
             'statusCode'   => $this->getStatusCode(),
             'timestamp'    => $this->getTimestamp(),
+            'date'         => $this->getDate(),
             'baseCurrency' => $this->getBaseCurrency(),
             'rates'        => $this->getRates()
         ]);

--- a/src/Response.php
+++ b/src/Response.php
@@ -33,7 +33,10 @@ class Response
         $this->timestamp    = date('c');
         $this->baseCurrency = $this->body->base;
         $this->rates        = $this->body->rates;
-        $this->date         = date('Y-m-d', strtotime($this->body->date));
+
+        if ($this->body->date) {
+            $this->date = date('Y-m-d', strtotime($this->body->date));
+        }
     }
     
     /****************************/


### PR DESCRIPTION
Two parts to this PR

1. Arrange access to the `date` property if it's being returned by the API (can be relevant when requesting `/latest` endpoint to doublecheck which date we actually got -- as data is being updated 5 minutes after GTM midnight according to their FAQ): 
https://api.exchangerate.host/latest
https://exchangerate.host/#/#faq
2. Fix the endpoint & parameters names for the from-to kind of requests: 
https://api.exchangerate.host/timeseries?start_date=2020-01-01&end_date=2020-01-04