### PR TITLE
Update SDK according to the latest API state

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ Following pricing changes for [ExchangeRatesAPI](https://exchangerate.host/), th
 2. [Getting Started](#2-getting-started)
 3. [API Reference](#3-api-reference)
 4. [Supported Currencies](#4-supported-currencies)
-5. [Supported data sources](#5-supported-data-sources)
-6. [Requirements](#6-requirements)
-7. [Bugs & Features](#7-bugs-features)
-8. [License](#8-license)
+5. [Requirements](#6-requirements)
+6. [Bugs & Features](#7-bugs-features)
+7. [License](#8-license)
 
 ---
 
@@ -123,18 +122,11 @@ Returns the `access_key` that is currently in use.
 `getUseSSL()`:<br />
 Returns a boolean flag that determines which API URL will be used to perform requests. Free plans are restricted to non-SSL usage.
 
-`getSource()`:<br />
-Returns the specified data source (other than the API default) from which to retrieve rates. Returns `null` if none is specified.
-
 `removeDateTo()`:<br />
 Removes the specified end date for the retrieval of historic rates.
 
 `currencyIsSupported( string $code )`:<br />
 Checks if a specific currency code is supported. `$code` should be passed as an ISO 4217 code (e.g. `EUR`).<br />
-Returns `true` if supported, or `false` if not.
-
-`sourceIsSupported( string $source )`:<br />
-Checks if a specific data source is supported.<br />
 Returns `true` if supported, or `false` if not.
 
 `setBaseCurrency( string $code )`:<br />
@@ -166,10 +158,6 @@ Sets `access_key` to be used in all requests.
 
 `setUseSSL( bool $use_ssl )`:<br />
 Sets the API URL according to the selected mode (SSL or non-SSL). Free plans are restricted to non-SSL usage.
-
-`setSource( string $source = null )`:<br />
-Sets the specified data source (other than the API default) from which to retrieve rates. Calling with no arguments resets the source to the API default.<br />
-If provided as a string, `$source` must be one of the [supported data sources](#5-supported-data-sources).
 
 `fetch( bool $returnJSON = false, bool $parseJSON = true )`:<br />
 Send off the request to the API and return either a `Response` object, or the raw JSON response. If `$returnJSON` is set to `true`, a standard PHP object will be returned, rather than the `ExchangeRatesAPI\Response` object. 
@@ -210,28 +198,22 @@ Returns a key/value pair array of the exchange rates that match against the requ
 ```
 
 `getRate( string $code )`:<br />
-Retrieves the exchange rate for a specific currency, or returns the exchange rate if only one rate is present in the response. 
-
-`getDate()`:<br />
-Retrieves the date returned as part of the response (formatted as Y-m-d). If response has no `date` property, returns null.
+Retrieves the exchange rate for a specific currency, or returns the exchange rate if only one rate is present in the response.
 
 ### 4. Supported Currencies:
 
 The library supports any currency currently available on the European Central Bank's web service, which can be found [here](https://exchangeratesapi.io/currencies/).
 
-### 5. Supported data sources:
-The library supports the following [data sources](https://api.exchangerate.host/sources) other than the API default.
-
-### 6. Requirements:
+### 5. Requirements:
 
 This library requires PHP >= 7.0. No other platform requirements exist, but the library is dependent on [Guzzle](https://github.com/guzzle/guzzle).
 
 
-### 7. Bugs & Features:
+### 6. Bugs & Features:
 
 If you have spotted any bugs, or would like to request additional features from the library, please file an issue via the Issue Tracker on the project's Github page: [https://github.com/benmajor/ExchangeRatesAPI/issues](https://github.com/benmajor/ExchangeRatesAPI/issues).
 
-### 8. License:
+### 7. License:
 
 Licensed under the **MIT License**:
 

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -92,7 +92,7 @@ class ExchangeRatesAPI
         $this->setAccessKey($access_key);
         $this->setUseSSL($use_ssl);
         
-        $this->client = new \GuzzleHttp\Client([ 'base_uri' => $this->apiURL]);
+        $this->client = new \GuzzleHttp\Client([ 'base_uri' => $this->apiURL ]);
     }
     
     /****************************/

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -92,7 +92,7 @@ class ExchangeRatesAPI
         $this->setAccessKey($access_key);
         $this->setUseSSL($use_ssl);
         
-        $this->client = new \GuzzleHttp\Client([ 'base_uri' => $this->apiURL, 'verify' => $use_ssl ]);
+        $this->client = new \GuzzleHttp\Client([ 'base_uri' => $this->apiURL]);
     }
     
     /****************************/

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -98,10 +98,7 @@ class ExchangeRatesAPI
         $this->setAccessKey($access_key);
         $this->setUseSSL($use_ssl);
         
-        $this->client = new \GuzzleHttp\Client([ 'base_uri' => $this->apiURL ]);
-        if (!$use_ssl) {
-            $this->client->setDefaultOption('verify', false);
-        }
+        $this->client = new \GuzzleHttp\Client([ 'base_uri' => $this->apiURL, 'verify' => $use_ssl ]);
     }
     
     /****************************/

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -99,6 +99,9 @@ class ExchangeRatesAPI
         $this->setUseSSL($use_ssl);
         
         $this->client = new \GuzzleHttp\Client([ 'base_uri' => $this->apiURL ]);
+        if (!$use_ssl) {
+            $this->client->setDefaultOption('verify', false);
+        }
     }
     
     /****************************/

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -74,18 +74,12 @@ class ExchangeRatesAPI
         'XOF', 'XPF', 'YER', 'ZAR', 'ZMK', 'ZMW', 'ZWL',
         ];
 
-    # Data source (default is forex which cannot be set explicitly):
-    private $source;
-
-    # Supported data sources:
-    private $_sources = ['imf', 'rba', 'boc', 'snb', 'cbr', 'nbu', 'bnro', 'boi', 'nob', 'cbn', 'ecb'];
 
     # Error messages:
     private $_errors = [
         'format.invalid_date'          => 'The specified date is invalid. Please use ISO 8601 notation (e.g. YYYY-MM-DD).',
         'format.invalid_currency_code' => 'The specified currency code is invalid. Please use ISO 4217 notation (e.g. EUR).',
         'format.unsupported_currency'  => 'The specified currency code is not currently supported.',
-        'format.unsupported_source'    => 'The specified data source is not currently supported.',
         'format.invalid_amount'        => 'Conversion amount must be specified as a numeric value.',
         'format.invalid_rounding'      => 'Rounding precision must be specified as a numeric value.'
     ];
@@ -134,7 +128,7 @@ class ExchangeRatesAPI
     # Get the specified base currency:
     public function getBaseCurrency()
     {
-        return (is_null($this->baseCurrency)) ? 'EUR' : $this->baseCurrency;
+        return (is_null($this->baseCurrency)) ? 'USD' : $this->baseCurrency;
     }
     
     # Get the rates:
@@ -155,12 +149,6 @@ class ExchangeRatesAPI
         return ($this->apiURL == self::API_URL_SSL);
     }
 
-    # Get data source
-    public function getSource()
-    {
-        return $this->source;
-    }
-    
     /****************************/
     /*                          */
     /*  SETTERS / DATA METHODS  */
@@ -240,12 +228,6 @@ class ExchangeRatesAPI
         return in_array( $currencyCode, $this->_currencies );
     }
 
-    # Check if a data source is in the supported range:
-    public function sourceIsSupported( string $source )
-    {
-        return in_array( $this->sanitizeSource($source), $this->_sources );
-    }
-    
     # Set the base currency:
     public function setBaseCurrency( string $currency )
     {
@@ -346,19 +328,6 @@ class ExchangeRatesAPI
         return $this;
     }
 
-    # Set data source
-    public function setSource(string $source = null)
-    {
-        if ($source !== null) {
-            $source = $this->sanitizeSource($source);
-            $this->verifySource($source);
-        }
-
-        $this->source = $source;
-
-        return $this;
-    }
-
     /****************************/
     /*                          */
     /*   API FUNCTION CALLS     */
@@ -429,19 +398,13 @@ class ExchangeRatesAPI
         # Set the base currency:
         if( ! is_null($this->getBaseCurrency()) )
         {
-            $params['base'] = $this->getBaseCurrency();
+            $params['source'] = $this->getBaseCurrency();
         }
         
         # Are there any rates set?
         if( count($this->rates) > 0 )
         {
-            $params['symbols'] = $this->getRates(',');
-        }
-
-        # Set the data source:
-        if( ! is_null($this->getSource()) )
-        {
-            $params['source'] = $this->getSource();
+            $params['currencies'] = $this->getRates(',');
         }
         
         # Begin the sending:
@@ -529,31 +492,11 @@ class ExchangeRatesAPI
         }
     }
 
-    # Runs tests to verify a source:
-    private function verifySource( string $source )
-    {
-        $source = $this->sanitizeSource($source);
-
-        # Is it a supported source?
-        if( ! $this->sourceIsSupported($source) )
-        {
-            throw new Exception( $this->_errors['format.unsupported_source'] );
-        }
-    }
-    
     # Sanitize a currency code:
     private function sanitizeCurrencyCode( string $code )
     {
         return trim(
             strtoupper( $code )
-        );
-    }
-
-    # Sanitize a data source:
-    private function sanitizeSource( string $source )
-    {
-        return trim(
-            strtolower( $source )
         );
     }
 }

--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -18,6 +18,9 @@ class ExchangeRatesAPI
     
     # Free plan API URL:
     const API_URL_NON_SSL = 'http://api.exchangerate.host/';
+
+    const ENDPOINT_MOST_RECENT_EXCHANGE_RATES = 'live';
+    const ENDPOINT_TIMEFRAME                  = 'timeframe';
     
     # Fetch date
     private $fetchDate;
@@ -404,11 +407,11 @@ class ExchangeRatesAPI
         # Set the relevant endpoint:
         if( is_null($this->dateFrom) )
         {
-            $endpoint = is_null($this->fetchDate) ? 'latest' : $this->fetchDate;
+            $endpoint = is_null($this->fetchDate) ? self::ENDPOINT_MOST_RECENT_EXCHANGE_RATES : $this->fetchDate;
         }
         else
         {
-            $endpoint = 'history';
+            $endpoint = self::ENDPOINT_TIMEFRAME;
         }
         
         # Add dateFrom if specified:

--- a/src/Response.php
+++ b/src/Response.php
@@ -30,9 +30,9 @@ class Response
         
         # Set our properties:
         $this->statusCode   = $response->getStatusCode();
-        $this->timestamp    = date('c');
-        $this->baseCurrency = $this->body->base;
-        $this->rates        = $this->body->rates;
+        $this->timestamp    = $this->body->timestamp;
+        $this->baseCurrency = $this->body->source;
+        $this->rates        = $this->body->quotes;
 
         if ($this->body->date) {
             $this->date = date('Y-m-d', strtotime($this->body->date));

--- a/src/Response.php
+++ b/src/Response.php
@@ -16,7 +16,6 @@ class Response
     private $statusCode;
     private $timestamp;
     private $baseCurrency;
-    private $date;
     
     private $rates = [ ];
     
@@ -33,10 +32,6 @@ class Response
         $this->timestamp    = $this->body->timestamp;
         $this->baseCurrency = $this->body->source;
         $this->rates        = $this->body->quotes;
-
-        if ($this->body->date) {
-            $this->date = date('Y-m-d', strtotime($this->body->date));
-        }
     }
     
     /****************************/
@@ -63,12 +58,6 @@ class Response
         return $this->baseCurrency;
     }
 
-    # Get the date specified in the response:
-    public function getDate()
-    {
-        return $this->date;
-    }
-    
     # Get the exchange rates:
     public function getRates()
     {
@@ -101,7 +90,6 @@ class Response
         return json_encode([
             'statusCode'   => $this->getStatusCode(),
             'timestamp'    => $this->getTimestamp(),
-            'date'         => $this->getDate(),
             'baseCurrency' => $this->getBaseCurrency(),
             'rates'        => $this->getRates()
         ]);


### PR DESCRIPTION
It looks like the API got some major updates, which makes the SDK unusable in its current state.
The PR makes it possible to keep getting the exchange rates and let the users fix the remaining incompatibilities on their side.

Changes that are handled by the PR:
- endpoints and request parameters are renamed
- `source` (as in, source of information) no longer exists, and now the name is used for the base currency
- `date` is no longer returned by any of the endpoints supported by this SDK (we could keep it but it makes more sense to add it back once someone adds support for `/historical` or `/convert` -- see if you agree)
- returned response body properties are renamed (`base` -> `source`, `rates` -> `quotes`)
- free plan no longer supports any other base currency than USD, so the default in the SDK is updated accordingly (could be left to the users but it made sense to do it here)

Breaking change that's considered out of scope of this PR: the returned rates (`quotes`) no longer seem to have currency codes as keys (`EUR`, `CHF` etc), instead they have both base and target currency glued together (`USDEUR`, `USDCHF` etc).
Fixing it could be a nice-to-have part of the SDK, but right now I'd rather fix things in a way where I can at least access the data -- and handle the rest on our side.

Documentation the PR is based on:
https://exchangerate.host/documentation